### PR TITLE
Add charter for TC-LOCALIZATION

### DIFF
--- a/_pages/charter/charter-TC-DEVGUIDE.md
+++ b/_pages/charter/charter-TC-DEVGUIDE.md
@@ -4,7 +4,7 @@ title: CalConnect DEVGUIDE Technical Committe
 parent: "/charter"
 mainParent: "charter"
 parents: "charter:/charter"
-order: 6
+order: 7
 ---
 
 CalConnect project to provide documentation on Calendaring and related issues.

--- a/_pages/charter/charter-TC-LOCALIZATION.md
+++ b/_pages/charter/charter-TC-LOCALIZATION.md
@@ -4,7 +4,7 @@ title: CalConnect LOCALIZATION Technical Committe
 parent: "/charter"
 mainParent: "charter"
 parents: "charter:/charter"
-order:
+order: 8
 ---
 
 # CalConnect LOCALIZATION Technical Committee

--- a/_pages/charter/charter-TC-LOCALIZATION.md
+++ b/_pages/charter/charter-TC-LOCALIZATION.md
@@ -1,0 +1,63 @@
+---
+layout: toc-type
+title: CalConnect LOCALIZATION Technical Committe
+parent: "/charter"
+mainParent: "charter"
+parents: "charter:/charter"
+order:
+---
+
+# CalConnect LOCALIZATION Technical Committee
+
+## Background
+
+Being able to read in one's own language should be a natural expectation.
+
+## Charter
+
+TC Localization will standardize on the approach of language localization, as
+well as representation of localized objects.
+
+The scope of localization includes, but is not limited to, transcription,
+transliteration and translation systems, as applied to prosal texts, personal
+and organizational names, postal addresses, as well as other relevant media of
+information.
+
+## Deliverables
+
+- localization for JSCalendar
+- vObject-i18n that introduces I18n features for vCard
+- "Transcription system code" with ISO/TC 46/WG 3
+- "Structured name standard" with ISO/TC 37/SC 4
+- Representation of localized objects and text with ISO/TC 37/SC 5
+
+## Begin and End Dates
+
+* **Begin:** October 2018
+* **End:** Standing Committee
+
+## Milestones and Work Products
+
+| Period       | Milestone    |
+| ---          | ---          |
+| October 2018 | TC initiated |
+
+## LOCALIZATION Mailing List
+
+You must be an employee of a CalConnect member to be subscribed to this mailing
+list except as approved by the TCC (e.g. representatives of liaison
+organizations).  You must be subscribed to this mailing list to post messages.
+
+[tc-localization-l](mailto:tc-localization-l@lists.calconnect.org)
+
+Participation on the TC-LOCALIZATION mailing list will be in accordance with
+standard CalConnect practices and procedures.
+
+## Co-Chairs
+
+Mike Douglass (SCG) ([mikeadouglass@gmail.com](mailto:mikeadouglass@gmail.com))
+
+Jeffrey Lau, Ribose ([jeffrey.lau@ribose.com](mailto:jeffrey.lau@ribose.com))
+
+Please contact the Chairs for more information or to join this Technical
+Committee.

--- a/_pages/charter/charter-TC-PUBLISH.md
+++ b/_pages/charter/charter-TC-PUBLISH.md
@@ -81,7 +81,7 @@ Participation on the TC-PUBLISH mailing list will be in accordance with standard
 
 
 
-## Co-Chairs        
+## Co-Chairs
 
 
 Dave Thewlis, CalConnect ([dave.thewlis@calconnect.org](mailto:dave.thewlis@calconnect.org))        

--- a/_pages/charter/charter-TC-PUBLISH.md
+++ b/_pages/charter/charter-TC-PUBLISH.md
@@ -4,7 +4,7 @@ title: CalConnect PUBLISH Technical Committe
 parent: "/charter"
 mainParent: "charter"
 parents: "charter:/charter"
-order: 7
+order: 9
 ---
 
 

--- a/_pages/charter/charter-TC-PUSH.md
+++ b/_pages/charter/charter-TC-PUSH.md
@@ -4,7 +4,7 @@ title: CalConnect PUSH Technical Committe
 parent: "/charter"
 mainParent: "charter"
 parents: "charter:/charter"
-order: 8
+order: 10
 ---
 
 # CalConnect PUSH Technical Committee

--- a/_pages/charter/charter-TC-SHARING.md
+++ b/_pages/charter/charter-TC-SHARING.md
@@ -4,7 +4,7 @@ title: CalConnect SHARING Technical Committe
 parent: "/charter"
 mainParent: "charter"
 parents: "charter:/charter"
-order: 9
+order: 11
 ---
 
 # CalConnect SHARING Technical Committee

--- a/_pages/charter/charter-TC-STREAMING.md
+++ b/_pages/charter/charter-TC-STREAMING.md
@@ -4,7 +4,7 @@ title: CalConnect STREAMING Technical Committe
 parent: "/charter"
 mainParent: "charter"
 parents: "charter:/charter"
-order: 10
+order: 12
 ---
 
 # CalConnect STREAMING Technical Committee

--- a/_pages/charter/charter-TC-TESTER.md
+++ b/_pages/charter/charter-TC-TESTER.md
@@ -4,7 +4,7 @@ title: CalConnect TESTER Technical Committe
 parent: "/charter"
 mainParent: "charter"
 parents: "charter:/charter"
-order: 11
+order: 13
 ---
 
 # CalConnect TESTER Technical Committee

--- a/_pages/charter/charter-TC-VCARD.md
+++ b/_pages/charter/charter-TC-VCARD.md
@@ -4,7 +4,7 @@ title: CalConnect VCARD Technical Committe
 parent: "/charter"
 mainParent: "charter"
 parents: "charter:/charter"
-order: 12
+order: 14
 ---
 
 # CalConnect VCARD Technical Committee


### PR DESCRIPTION
This pull request adds a charter for TC-LOCALIZATION.

Suggestions welcome.

A summary of changes made thus far:

- I renumbered the `order:` for each charter document to make them sort alphabetically.  TCC is kept in the 5th position untouched, right after CALSPAM and before DATETIME.  (Is this the correct approach?)
- Also converted the TC-PUBLISH document to use Unix line endings for consistency, to prepare for the above `order:`-renumbering work.

cc: @douglm 